### PR TITLE
#6 Move snap point rendering to call site

### DIFF
--- a/stories/carousel.stories.tsx
+++ b/stories/carousel.stories.tsx
@@ -7,15 +7,20 @@ export default {
 };
 
 export const Default = () => {
-  const items = Array.from({ length: 18 });
+  const items = Array.from({ length: 18 }).map((_, index) => ({ id: index }));
   return (
-    <Carousel>
-      {items.map((_, i) => (
-        <CarouselItem key={i} bgColor={getColor(i)}>
-          {i + 1}
+    <Carousel
+      items={items}
+      renderItem={({ item, index, isSnapPoint }) => (
+        <CarouselItem
+          key={item.id}
+          isSnapPoint={isSnapPoint}
+          bgColor={getColor(index)}
+        >
+          {index + 1}
         </CarouselItem>
-      ))}
-    </Carousel>
+      )}
+    />
   );
 };
 
@@ -24,34 +29,48 @@ export const VariableWidth = () => {
     110, 300, 500, 120, 250, 300, 500, 400, 180, 300, 350, 700, 400, 230, 300
   ];
   return (
-    <Carousel>
-      {items.map((width, i) => (
-        <CarouselItem key={i} bgColor={getColor(i)} width={width}>
-          {i + 1}
+    <Carousel
+      items={items}
+      renderItem={({ item: width, index, isSnapPoint }) => (
+        <CarouselItem
+          key={index}
+          isSnapPoint={isSnapPoint}
+          bgColor={getColor(index)}
+          width={width}
+        >
+          {index + 1}
         </CarouselItem>
-      ))}
-    </Carousel>
+      )}
+    />
   );
 };
 
 export const VerticalAxis = () => {
-  const items = Array.from({ length: 18 });
+  const items = Array.from({ length: 18 }).map((_, index) => ({ id: index }));
   return (
-    <Carousel axis="y">
-      {items.map((_, i) => (
-        <CarouselItem key={i} bgColor={getColor(i)}>
-          {i + 1}
+    <Carousel
+      axis="y"
+      items={items}
+      renderItem={({ item, index, isSnapPoint }) => (
+        <CarouselItem
+          key={item.id}
+          isSnapPoint={isSnapPoint}
+          bgColor={getColor(index)}
+        >
+          {index + 1}
         </CarouselItem>
-      ))}
-    </Carousel>
+      )}
+    />
   );
 };
 
 export const DynamicItems = () => {
   const carouselRef = useRef<CarouselRef>(null);
-  const [items, setItems] = useState(() => Array.from({ length: 1 }));
+  const [items, setItems] = useState(() =>
+    Array.from({ length: 1 }).map((_, index) => ({ id: index }))
+  );
   const addItem = () => {
-    setItems((prev) => [...prev, undefined]);
+    setItems((prev) => [...prev, { id: prev.length }]);
   };
   const removeItem = () => {
     setItems((prev) => prev.slice(0, -1));
@@ -66,13 +85,19 @@ export const DynamicItems = () => {
     <>
       <Button onClick={() => removeItem()}>Remove Item</Button>
       <Button onClick={() => addItem()}>Add Item</Button>
-      <Carousel ref={carouselRef}>
-        {items.map((_, i) => (
-          <CarouselItem key={i} bgColor={getColor(i)}>
-            {i + 1}
+      <Carousel
+        ref={carouselRef}
+        items={items}
+        renderItem={({ item, index, isSnapPoint }) => (
+          <CarouselItem
+            key={item.id}
+            isSnapPoint={isSnapPoint}
+            bgColor={getColor(index)}
+          >
+            {index + 1}
           </CarouselItem>
-        ))}
-      </Carousel>
+        )}
+      />
     </>
   );
 };

--- a/stories/slideshow.module.css
+++ b/stories/slideshow.module.css
@@ -23,6 +23,10 @@
   overflow: hidden;
 }
 
+.snapPoint {
+  scroll-snap-align: start;
+}
+
 .itemText {
   position: absolute;
   z-index: 100;

--- a/stories/slideshow.stories.tsx
+++ b/stories/slideshow.stories.tsx
@@ -26,18 +26,18 @@ const items = [
 
 export const Default = () => {
   return (
-    <SlideShow>
-      {({ activePageIndex }) =>
-        items.map((item, i) => (
-          <SlideShowItem
-            key={i}
-            src={item.src}
-            title={item.title}
-            subtitle={item.subtitle}
-            active={activePageIndex === i}
-          />
-        ))
-      }
-    </SlideShow>
+    <SlideShow
+      items={items}
+      renderItem={({ item, index, isActive, isSnapPoint }) => (
+        <SlideShowItem
+          key={index}
+          isSnapPoint={isSnapPoint}
+          isActive={isActive}
+          src={item.src}
+          title={item.title}
+          subtitle={item.subtitle}
+        />
+      )}
+    />
   );
 };

--- a/stories/slideshow.tsx
+++ b/stories/slideshow.tsx
@@ -8,19 +8,32 @@ const styles = require('./slideshow.module.css');
  * This is an example Carousel built on top of `useSnapCarousel`
  */
 
-export interface SlideShowProps {
-  readonly children?:
-    | React.ReactNode
-    | ((props: SlideShowRenderProps) => React.ReactNode);
+export interface SlideShowProps<T> {
+  readonly items: T[];
+  readonly renderItem: (props: SlideShowRenderItemProps<T>) => React.ReactNode;
 }
 
-export interface SlideShowRenderProps {
-  readonly activePageIndex: number;
+export interface SlideShowRenderItemProps<T> {
+  readonly item: T;
+  readonly index: number;
+  readonly isSnapPoint: boolean;
+  readonly isActive: boolean;
 }
 
-export const SlideShow = ({ children }: SlideShowProps = {}) => {
-  const { scrollRef, next, prev, goTo, pages, activePageIndex, refresh } =
-    useSnapCarousel();
+export const SlideShow = <T extends any>({
+  items,
+  renderItem
+}: SlideShowProps<T>) => {
+  const {
+    scrollRef,
+    next,
+    prev,
+    goTo,
+    pages,
+    activePageIndex,
+    snapPointIndexes,
+    refresh
+  } = useSnapCarousel();
 
   useEffect(() => {
     const handle = (e: KeyboardEvent) => {
@@ -44,9 +57,14 @@ export const SlideShow = ({ children }: SlideShowProps = {}) => {
   return (
     <div className={styles.root}>
       <ul className={styles.scroll} ref={scrollRef}>
-        {typeof children === 'function'
-          ? children({ activePageIndex })
-          : children}
+        {items.map((item, index) =>
+          renderItem({
+            item,
+            index,
+            isSnapPoint: snapPointIndexes.has(index),
+            isActive: activePageIndex === index
+          })
+        )}
       </ul>
       <div className={styles.pageIndicator}>
         {activePageIndex + 1} / {pages.length}
@@ -89,22 +107,25 @@ export const SlideShow = ({ children }: SlideShowProps = {}) => {
 };
 
 export interface SlideShowItemProps {
+  readonly isSnapPoint: boolean;
+  readonly isActive: boolean;
   readonly src: string;
   readonly title: string;
   readonly subtitle: string;
-  readonly active: boolean;
 }
 
 export const SlideShowItem = ({
+  isSnapPoint,
+  isActive,
   src,
-  active,
   title,
   subtitle
 }: SlideShowItemProps) => {
   return (
     <li
       className={classNames(styles.item, {
-        [styles.itemActive]: active
+        [styles.snapPoint]: isSnapPoint,
+        [styles.itemActive]: isActive
       })}
     >
       <div className={styles.itemText}>


### PR DESCRIPTION
https://github.com/richardscarrott/react-snap-carousel/issues/6

It's now up to the `<Carousel />` implementor to render the snap points (`scroll-snap-align: start;`) using `snapPointIndexes`.

```ts
const {
  snapPointIndexes // Set {0, 3, 6, 9, 12}
} = useSnapCarousel();
```

A `<Carousel />` implementation could expose this however they see fit, I like the following render prop APIs:

```ts
const items = [{ id: 1 }, { id: 2 }, { id: 3 }];

// ...

<Carousel
  items={items}
  renderItem={({ item, isSnapPoint }) => (
    <CarouselItem key={item.id} item={item} isSnapPoint={isSnapPoint} />
  )}
/>
```

Or

```ts
const items = [{ id: 1 }, { id: 2 }, { id: 3 }];

// ...

<Carousel>
  {({ snapPointIndexes }) =>
    items.map((item, i) => (
      <CarouselItem
        key={item.id}
        item={item}
        isSnapPoint={snapPointIndexes.has(i)}
      />
    ))
  }
</Carousel>
```

But if you prefer to use React context, or React.cloneElement, you can.

https://beta.reactjs.org/reference/react/cloneElement#alternatives

Storybook `Carousel` & `SlideShow` can be used as reference.

### TODO:
- [ ] Update example in README
- [ ] Once published, update CodeSandbox StarterKit