### PR TITLE
#3 Add support for scroll padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^4.8.3"
   },
   "scripts": {
-    "build": "tsup src/use-snap-carousel.tsx --format esm,cjs --dts --clean",
+    "build": "tsup src/use-snap-carousel.tsx --format esm,cjs --dts --clean --minify",
     "test": "jest",
     "prepublishOnly": "npm run test && npm run build",
     "storybook": "start-storybook -p 6006",

--- a/stories/carousel.module.css
+++ b/stories/carousel.module.css
@@ -18,9 +18,9 @@
   scroll-snap-type: x mandatory;
   -ms-overflow-style: none;
   scrollbar-width: none;
-  /* TODO: Add better support for scroll-padding / scroll-margin */
-  /* scroll-padding: 0 1rem;
-  padding: 0 1rem; */
+  overscroll-behavior: contain;
+  scroll-padding: 0 16px;
+  padding: 0 16px;
 }
 
 .scroll::-webkit-scrollbar {
@@ -30,8 +30,8 @@
 .y .scroll {
   display: block;
   scroll-snap-type: y mandatory;
-  scroll-padding: 1rem 0;
-  padding: 1rem 0 0 0;
+  scroll-padding: 16px 0;
+  padding: 16px 0;
 }
 
 .item {

--- a/stories/slideshow.module.css
+++ b/stories/slideshow.module.css
@@ -2,6 +2,10 @@
   position: relative;
 }
 
+.scrollPadding {
+  margin: 0 -1rem; /* bust out of storybook margin (to demonstrate full bleed carousel) */
+}
+
 .scroll {
   position: relative;
   display: flex;
@@ -9,6 +13,13 @@
   scroll-snap-type: x mandatory;
   -ms-overflow-style: none;
   scrollbar-width: none;
+  box-sizing: border-box;
+  overscroll-behavior: contain;
+}
+
+.scrollPadding .scroll {
+  scroll-padding: 0 5%;
+  padding: 0 5%;
 }
 
 .scroll::-webkit-scrollbar {
@@ -21,7 +32,13 @@
   position: relative;
   padding-bottom: 56.25%;
   overflow: hidden;
+  /* margin: 0 1%; */
 }
+
+/* .item:first-child,
+.item:last-child {
+  margin: 0;
+} */
 
 .snapPoint {
   scroll-snap-align: start;

--- a/stories/slideshow.stories.tsx
+++ b/stories/slideshow.stories.tsx
@@ -41,3 +41,22 @@ export const Default = () => {
     />
   );
 };
+
+export const ScrollPadding = () => {
+  return (
+    <SlideShow
+      scrollPadding
+      items={items}
+      renderItem={({ item, index, isActive, isSnapPoint }) => (
+        <SlideShowItem
+          key={index}
+          isSnapPoint={isSnapPoint}
+          isActive={isActive}
+          src={item.src}
+          title={item.title}
+          subtitle={item.subtitle}
+        />
+      )}
+    />
+  );
+};

--- a/stories/slideshow.tsx
+++ b/stories/slideshow.tsx
@@ -13,6 +13,7 @@ export interface SlideShowProps<T> {
   readonly renderItem: (
     props: SlideShowRenderItemProps<T>
   ) => React.ReactElement<SlideShowItemProps>;
+  readonly scrollPadding?: boolean;
 }
 
 export interface SlideShowRenderItemProps<T> {
@@ -24,7 +25,8 @@ export interface SlideShowRenderItemProps<T> {
 
 export const SlideShow = <T extends any>({
   items,
-  renderItem
+  renderItem,
+  scrollPadding = false
 }: SlideShowProps<T>) => {
   const {
     scrollRef,
@@ -57,7 +59,11 @@ export const SlideShow = <T extends any>({
   }, [next, prev]);
 
   return (
-    <div className={styles.root}>
+    <div
+      className={classNames(styles.root, {
+        [styles.scrollPadding]: scrollPadding
+      })}
+    >
       <ul className={styles.scroll} ref={scrollRef}>
         {items.map((item, index) =>
           renderItem({


### PR DESCRIPTION
#3 

<img width="781" alt="Screenshot 2023-02-10 at 15 18 58" src="https://user-images.githubusercontent.com/539309/218128222-02b48f5a-706c-4ef7-9b5b-e49191451111.png">

<img width="764" alt="Screenshot 2023-02-10 at 15 19 24" src="https://user-images.githubusercontent.com/539309/218128241-167be6d7-bcf8-48e2-8862-d4c01c9813f8.png">

## Notes
- There is no API to get the [used](https://developer.mozilla.org/en-US/docs/Web/CSS/used_value) scroll padding value so this PR includes a fn which attempts to figure out the used value.
   - This means there are limitations. 
      - If the [computed value](https://developer.mozilla.org/en-US/docs/Web/CSS/computed_value) is `px`, it's all good (this includes `px`, `rem`, `vw`, `em`, `cal(1px + 1px)` etc.).
      - If the computed value is a simple `%` value (i.e. it depends on layout), it will figure that out too.
      - However, it won't figure out more complex percentage values such as `calc(10% + 1px)` and opts to throw instead.
- There are some subtle differences between how browsers determine which item to snap to when padding and margin are involved, but this works accurately in the vast majority of cases.
- `scroll-margin` isn't yet factored in. It should be pretty easy to do in `getEffectiveScrollPadding` (I expect it should be renamed to `getEffectiveScrollSpacing`) as they're additive AFAIK. #3 
