### PR TITLE
#4 Accept initialPages as option to enhance SSR ability

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^4.8.3"
   },
   "scripts": {
-    "build": "tsup src/use-snap-carousel.tsx --format esm,cjs --dts --clean --minify",
+    "build": "tsup src/use-snap-carousel.tsx --format esm,cjs --dts --clean",
     "test": "jest",
     "prepublishOnly": "npm run test && npm run build",
     "storybook": "start-storybook -p 6006",

--- a/src/use-snap-carousel.tsx
+++ b/src/use-snap-carousel.tsx
@@ -19,6 +19,7 @@ export interface SnapCarouselResult {
 
 export interface SnapCarouselOptions {
   readonly axis?: 'x' | 'y';
+  readonly initialPages?: number[][];
 }
 
 interface SnapCarouselState {
@@ -27,7 +28,8 @@ interface SnapCarouselState {
 }
 
 export const useSnapCarousel = ({
-  axis = 'x'
+  axis = 'x',
+  initialPages = []
 }: SnapCarouselOptions = {}): SnapCarouselResult => {
   const dimension = axis === 'x' ? 'width' : 'height';
   const scrollDimension = axis === 'x' ? 'scrollWidth' : 'scrollHeight';
@@ -42,7 +44,7 @@ export const useSnapCarousel = ({
   // not implicitly rely on set state batching)
   const [{ pages, activePageIndex }, setCarouselState] =
     useState<SnapCarouselState>({
-      pages: [],
+      pages: initialPages,
       activePageIndex: 0
     });
 


### PR DESCRIPTION
https://github.com/richardscarrott/react-snap-carousel/issues/4

Good for when no. of pages are known (e.g. there's only 1) or even handy if you want to set the controls opacity to 0 until hydrated as you can at least render 1 page link to ensure the correct height is taken up.

I didn't offer up `initialActivePageIndex` as I'm pretty confident it's not possible to have a scrollable div start with a scroll position of anything other than 0...