### PR TITLE
Add autoRefreshCondition optional prop to useSnapCarousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ interface SnapCarouselOptions {
   readonly axis?: 'x' | 'y';
   // Allows you to render pagination during SSR
   readonly initialPages?: number[][];
+  // Control Snap Carousel's automatic refresh (on layout change, scroll, etc.)
+  readonly autoRefreshCondition ?: () => boolean;
 }
 ```
 

--- a/src/use-snap-carousel.tsx
+++ b/src/use-snap-carousel.tsx
@@ -15,6 +15,7 @@ export interface SnapCarouselResult {
 export interface SnapCarouselOptions {
   readonly axis?: 'x' | 'y';
   readonly initialPages?: number[][];
+  readonly refreshCondition?: () => boolean;
 }
 
 interface SnapCarouselState {
@@ -24,7 +25,8 @@ interface SnapCarouselState {
 
 export const useSnapCarousel = ({
   axis = 'x',
-  initialPages = []
+  initialPages = [],
+  refreshCondition = () => true
 }: SnapCarouselOptions = {}): SnapCarouselResult => {
   const dimension = axis === 'x' ? 'width' : 'height';
   const scrollDimension = axis === 'x' ? 'scrollWidth' : 'scrollHeight';
@@ -83,7 +85,7 @@ export const useSnapCarousel = ({
   );
 
   const refresh = useCallback(() => {
-    if (!scrollEl) {
+    if (!scrollEl || !refreshCondition()) {
       return;
     }
     const items = Array.from(scrollEl.children);

--- a/src/use-snap-carousel.tsx
+++ b/src/use-snap-carousel.tsx
@@ -112,7 +112,7 @@ export const useSnapCarousel = ({
       return acc;
     }, []);
     refreshActivePage(pages);
-  }, [refreshActivePage, scrollEl, dimension, farSidePos, nearSidePos]);
+  }, [refreshActivePage, scrollEl, dimension, farSidePos, nearSidePos, refreshCondition]);
 
   useIsomorphicLayoutEffect(() => {
     refresh();


### PR DESCRIPTION
# What does this add?

This adds a new prop, `autoRefreshCondition ?: () => boolean = () => true;`.  This prop lets an implementation enable or disable uncontrolled refreshes, e.g. on scroll, on resize, etc.

# Why is this important?

Allowing implementation control of auto-refresh enables more fine-grained control over the application's UI state.  Additionally, the overhead required to add this functionality is minimal.

# Example Use Case

The main reason I added this was to allow switching between a carousel view and an "expanded" view.  This really only toggles a class that adds `flex-wrap: wrap;` to the carousel.  I also want to be able to hide this functionality when the expanded view isn't required, and to do so, I rely on `pages.length` (when `pages.length > 1`, show the toggle).  The downside here is that if I add wrapping to the carousel and the layout changes, pages.length automatically changes to 1 and I can no longer access the toggle from that point forward.  Being able to disable uncontrolled refreshes will enable this use case. 