### PR TITLE
Prevent iOS <= 14 from blowing up when reading scroll margin or padding

### DIFF
--- a/src/use-snap-carousel.tsx
+++ b/src/use-snap-carousel.tsx
@@ -258,7 +258,8 @@ const _getOffsetRect = (el: Element) => {
 // https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding
 const getScrollPaddingUsedValue = (el: HTMLElement, pos: 'left' | 'top') => {
   const style = window.getComputedStyle(el);
-  const scrollPadding = style.getPropertyValue(`scroll-padding-${pos}`);
+  const scrollPadding =
+    style.getPropertyValue(`scroll-padding-${pos}`) || '0px';
   if (scrollPadding === 'auto') {
     return 0;
   }
@@ -284,9 +285,10 @@ const getScrollPaddingUsedValue = (el: HTMLElement, pos: 'left' | 'top') => {
 // https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin
 const getScrollMarginUsedValue = (el: HTMLElement, pos: 'left' | 'top') => {
   const style = window.getComputedStyle(el);
-  const scrollMargin = style.getPropertyValue(`scroll-margin-${pos}`);
+  const scrollMargin = style.getPropertyValue(`scroll-margin-${pos}`) || '0px';
   // https://developer.mozilla.org/en-US/docs/Web/CSS/length
   // https://www.w3.org/TR/css3-values/#length-value
+  // alert(scrollMargin);
   const invalidMsg = `Unsupported scroll margin value, expected <length> value, received ${scrollMargin}`;
   assert(scrollMargin.endsWith('px'), invalidMsg); // Even scroll-margin: 0 should return "0px"
   const value = parseInt(scrollMargin);

--- a/src/use-snap-carousel.tsx
+++ b/src/use-snap-carousel.tsx
@@ -288,7 +288,6 @@ const getScrollMarginUsedValue = (el: HTMLElement, pos: 'left' | 'top') => {
   const scrollMargin = style.getPropertyValue(`scroll-margin-${pos}`) || '0px';
   // https://developer.mozilla.org/en-US/docs/Web/CSS/length
   // https://www.w3.org/TR/css3-values/#length-value
-  // alert(scrollMargin);
   const invalidMsg = `Unsupported scroll margin value, expected <length> value, received ${scrollMargin}`;
   assert(scrollMargin.endsWith('px'), invalidMsg); // Even scroll-margin: 0 should return "0px"
   const value = parseInt(scrollMargin);


### PR DESCRIPTION
https://github.com/richardscarrott/react-snap-carousel/issues/25

Reproduced, fixed and tested using browser stack.