### PR TITLE
Support infinite carousels

### DIFF
--- a/src/use-snap-carousel.tsx
+++ b/src/use-snap-carousel.tsx
@@ -105,6 +105,10 @@ export const useSnapCarousel = ({
       const rect = getOffsetRect(item, item.parentElement);
       if (
         !currPage ||
+        // We allow items to explicitly mark themselves as snap points via the `data-should-snap`
+        // attribute. This allows callsites to augment and/or define their own "page" logic.
+        item.dataset.shouldSnap === 'true' ||
+        // Otherwise, we determine pages via the layout.
         rect[farSidePos] - currPageStartPos > Math.ceil(scrollPort[dimension])
       ) {
         acc.push([i]);

--- a/stories/infinite-carousel.module.css
+++ b/stories/infinite-carousel.module.css
@@ -1,0 +1,156 @@
+.root {
+  position: relative;
+  margin: 0 -1rem; /* bust out of storybook margin (to demonstrate full bleed carousel) */
+}
+
+.y.root {
+  margin: -1rem 0;
+  height: 100vh;
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+}
+
+.scroll {
+  position: relative;
+  display: flex;
+  overflow: auto;
+  scroll-snap-type: x mandatory;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  overscroll-behavior: contain;
+  scroll-padding: 0 16px;
+  padding: 0 16px;
+}
+
+.scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.y .scroll {
+  display: block;
+  scroll-snap-type: y mandatory;
+  scroll-padding: 16px 0;
+  padding: 16px 0;
+}
+
+.item {
+  font-family: Futura, Trebuchet MS, Arial, sans-serif;
+  font-size: 125px;
+  line-height: 1;
+  width: 300px;
+  height: 300px;
+  max-width: 100%;
+  flex-shrink: 0;
+  color: white;
+  display: flex;
+  justify-content: end;
+  align-items: end;
+  padding: 16px 20px;
+  text-transform: uppercase;
+  text-shadow: 6px 6px 0px rgba(0, 0, 0, 0.2);
+  margin-right: 0.6rem;
+  overflow: hidden;
+}
+
+.scrollMargin .item:nth-child(9) {
+  scroll-margin-left: 200px;
+  background: black !important;
+}
+
+.item:last-child {
+  margin-right: 0;
+}
+
+.y .item {
+  margin-right: 0;
+  margin-bottom: 0.6rem;
+}
+
+.y .item:last-child {
+  margin-bottom: 0;
+}
+
+.pageIndicator {
+  font-family: Futura, Trebuchet MS, Arial, sans-serif;
+  font-weight: bold;
+  font-size: 14px;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.5);
+  pointer-events: none;
+  border-radius: 5px;
+  color: #374151;
+}
+
+.controls {
+  margin: 1rem 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #374151;
+  padding: 0 1rem;
+}
+
+.prevButton,
+.nextButton {
+  font-size: 18px;
+  transition: opacity 100ms ease-out;
+}
+
+.prevButton[disabled],
+.nextButton[disabled] {
+  opacity: 0.4;
+}
+
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 0 10px;
+}
+
+.paginationItem {
+  display: flex;
+  justify-content: center;
+}
+
+.paginationButton {
+  display: block;
+  text-indent: -99999px;
+  overflow: hidden;
+  background: #374151;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin: 5px;
+  transition: opacity 100ms ease-out;
+}
+
+.paginationItemActive .paginationButton {
+  opacity: 0.3;
+}
+
+@media only screen and (max-width: 480px) {
+  .item {
+    width: 280px;
+    height: 280px;
+  }
+
+  .pagination {
+    margin: 0 8px;
+  }
+
+  .prevButton,
+  .nextButton {
+    font-size: 15px;
+  }
+
+  .paginationButton {
+    width: 9px;
+    height: 9px;
+    margin: 4px;
+  }
+}

--- a/stories/infinite-carousel.stories.tsx
+++ b/stories/infinite-carousel.stories.tsx
@@ -1,0 +1,168 @@
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import {
+  InfiniteCarousel,
+  InfiniteCarouselItem,
+  InfiniteCarouselRef
+} from './infinite-carousel';
+import { Button } from './lib/button';
+import { Select } from './lib/select';
+
+export default {
+  title: 'Infinite Carousel',
+  component: InfiniteCarousel
+};
+
+export const Default = () => {
+  const items = Array.from({ length: 18 }).map((_, index) => ({
+    id: index,
+    index
+  }));
+  return (
+    <InfiniteCarousel
+      items={items}
+      renderItem={({ item, index, isSnapPoint, shouldSnap }) => (
+        <InfiniteCarouselItem
+          key={index}
+          isSnapPoint={isSnapPoint}
+          shouldSnap={shouldSnap}
+          bgColor={getColor(item.index)}
+        >
+          {item.index + 1}
+        </InfiniteCarouselItem>
+      )}
+    />
+  );
+};
+
+export const VariableWidth = () => {
+  const items = [
+    110, 300, 500, 120, 250, 300, 500, 400, 180, 300, 350, 700, 400, 230, 300
+  ].map((width, index) => ({ id: index, index, width }));
+  return (
+    <InfiniteCarousel
+      items={items}
+      renderItem={({ item, index, isSnapPoint, shouldSnap }) => (
+        <InfiniteCarouselItem
+          key={index}
+          isSnapPoint={isSnapPoint}
+          shouldSnap={shouldSnap}
+          bgColor={getColor(item.index)}
+          width={item.width}
+        >
+          {item.index + 1}
+        </InfiniteCarouselItem>
+      )}
+    />
+  );
+};
+
+export const VerticalAxis = () => {
+  const items = Array.from({ length: 18 }).map((_, index) => ({
+    id: index,
+    index
+  }));
+  return (
+    <InfiniteCarousel
+      axis="y"
+      items={items}
+      renderItem={({ item, index, isSnapPoint, shouldSnap }) => (
+        <InfiniteCarouselItem
+          key={index}
+          isSnapPoint={isSnapPoint}
+          shouldSnap={shouldSnap}
+          bgColor={getColor(item.index)}
+        >
+          {item.index + 1}
+        </InfiniteCarouselItem>
+      )}
+    />
+  );
+};
+
+export const DynamicItems = () => {
+  const carouselRef = useRef<InfiniteCarouselRef>(null);
+  const [items, setItems] = useState(() =>
+    Array.from({ length: 6 }).map((_, index) => ({ id: index, index }))
+  );
+  const addItem = () => {
+    setItems((prev) => [...prev, { id: prev.length, index: prev.length }]);
+  };
+  const removeItem = () => {
+    setItems((prev) => prev.slice(0, -1));
+  };
+  useLayoutEffect(() => {
+    if (!carouselRef.current) {
+      return;
+    }
+    carouselRef.current.refresh();
+  }, [items]);
+  return (
+    <>
+      <div style={{ display: 'flex', gap: '10px', margin: '0 0 10px' }}>
+        <Button onClick={() => removeItem()}>Remove Item</Button>
+        <Button onClick={() => addItem()}>Add Item</Button>
+      </div>
+      <InfiniteCarousel
+        ref={carouselRef}
+        items={items}
+        renderItem={({ item, index, isSnapPoint, shouldSnap }) => (
+          <InfiniteCarouselItem
+            key={index}
+            isSnapPoint={isSnapPoint}
+            shouldSnap={shouldSnap}
+            bgColor={getColor(item.index)}
+          >
+            {item.index + 1}
+          </InfiniteCarouselItem>
+        )}
+      />
+    </>
+  );
+};
+
+export const ScrollBehavior = () => {
+  const scrollBehaviors: ScrollBehavior[] = ['smooth', 'instant', 'auto'];
+  const [scrollBehavior, setScrollBehavior] = useState(scrollBehaviors[0]);
+  const items = Array.from({ length: 18 }).map((_, index) => ({
+    id: index,
+    index
+  }));
+  return (
+    <>
+      <div style={{ margin: '0 0 10px' }}>
+        <Select
+          onChange={(e) => {
+            setScrollBehavior(e.target.value as ScrollBehavior);
+          }}
+          value={scrollBehavior}
+        >
+          {scrollBehaviors.map((value) => (
+            <option key={value} value={value}>
+              {value.slice(0, 1).toUpperCase() + value.slice(1)}
+            </option>
+          ))}
+        </Select>
+      </div>
+      <InfiniteCarousel
+        scrollBehavior={scrollBehavior}
+        items={items}
+        renderItem={({ item, index, isSnapPoint, shouldSnap }) => (
+          <InfiniteCarouselItem
+            key={index}
+            isSnapPoint={isSnapPoint}
+            shouldSnap={shouldSnap}
+            bgColor={getColor(item.index)}
+          >
+            {item.index + 1}
+          </InfiniteCarouselItem>
+        )}
+      />
+    </>
+  );
+};
+
+/* Utils */
+
+const getColor = (i: number) => {
+  return `hsl(-${i * 12} 100% 50%)`;
+};

--- a/stories/infinite-carousel.tsx
+++ b/stories/infinite-carousel.tsx
@@ -1,0 +1,183 @@
+import React, { useImperativeHandle, useMemo, useLayoutEffect } from 'react';
+import classNames from 'classnames';
+import { useSnapCarousel } from '../src/use-snap-carousel';
+import './reset.css';
+const styles = require('./infinite-carousel.module.css');
+
+/**
+ * This is an example of an infinite carousel built on top of `useSnapCarousel`
+ *
+ * NOTE: This is not truly infinite, but rather it's as-good-as-infinite because, in order to keep
+ * complexity low, it merely duplicates items in either direction rather than trying to dynamically
+ * change the scroll position.
+ */
+
+export interface InfiniteCarouselProps<T> {
+  readonly axis?: 'x' | 'y';
+  readonly items: T[];
+  readonly renderItem: (
+    props: InfiniteCarouselRenderItemProps<T>
+  ) => React.ReactElement<InfiniteCarouselItemProps>;
+  readonly scrollMargin?: boolean;
+  readonly scrollBehavior?: ScrollBehavior;
+}
+
+export interface InfiniteCarouselRenderItemProps<T> {
+  readonly item: T;
+  readonly index: number;
+  readonly isSnapPoint: boolean;
+  readonly shouldSnap: boolean;
+}
+
+export interface InfiniteCarouselRef {
+  readonly refresh: () => void;
+}
+
+export const InfiniteCarousel = React.forwardRef<
+  InfiniteCarouselRef,
+  InfiniteCarouselProps<unknown>
+>(
+  ({ axis, items, renderItem, scrollMargin = false, scrollBehavior }, ref) => {
+    const {
+      scrollRef,
+      next,
+      prev,
+      goTo,
+      pages,
+      activePageIndex,
+      snapPointIndexes,
+      refresh
+    } = useSnapCarousel({ axis });
+
+    useImperativeHandle(ref, () => ({ refresh }));
+
+    // 1. Duplicate the items to create the illusion of infinity.
+    const duplicationFactor = items.length ? Math.ceil(250 / items.length) : 0;
+    const itemsToRender = useMemo(
+      () => Array.from({ length: duplicationFactor }).flatMap(() => items),
+      [duplicationFactor, items]
+    );
+
+    // 2. Jump to the middle-most "first" page to minimize the chance of scrolling to either end.
+    useLayoutEffect(() => {
+      const itemsByPage = pages.map((page) =>
+        page.map((idx) => itemsToRender[idx])
+      );
+      const allFirstPages = itemsByPage.filter(
+        (page) => page[0] === itemsToRender[0]
+      );
+      const mid = allFirstPages[Math.floor(allFirstPages.length / 2)];
+      goTo(itemsByPage.indexOf(mid), {
+        behavior: 'instant'
+      });
+      // Need `useEffectEvent`
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [pages, itemsToRender]);
+
+    // 3. Define the logical pages and the active page index to render based on the actual unique `items`.
+    const pagesToRender = pages.filter((page) => page[0] <= items.length - 1);
+    const activePageIndexToRender = pagesToRender.length
+      ? activePageIndex % pagesToRender.length
+      : -1;
+
+    return (
+      <div
+        className={classNames(styles.root, {
+          [styles.x]: axis === 'x',
+          [styles.y]: axis === 'y',
+          [styles.scrollMargin]: scrollMargin
+        })}
+      >
+        <ul className={styles.scroll} ref={scrollRef}>
+          {itemsToRender.map((item, index) =>
+            renderItem({
+              item,
+              index,
+              isSnapPoint: snapPointIndexes.has(index),
+              // 4. Force snapping to the first item so that pages are always made up of the equivalent
+              // items, even if the number of items isn't wholly divisible by the number of pages.
+              // -- this simplifies the logic for rendering the controls.
+              shouldSnap: item === itemsToRender[0]
+            })
+          )}
+        </ul>
+        <div className={styles.pageIndicator}>
+          {activePageIndexToRender + 1} / {pagesToRender.length}
+        </div>
+        <div className={styles.controls}>
+          <button
+            disabled={activePageIndex <= 0}
+            onClick={() => prev({ behavior: scrollBehavior })}
+            className={styles.prevButton}
+          >
+            {String.fromCharCode(8592)}
+          </button>
+          <ol className={styles.pagination}>
+            {pagesToRender.map((_, i) => (
+              <li
+                key={i}
+                className={classNames(styles.paginationItem, {
+                  [styles.paginationItemActive]: i === activePageIndexToRender
+                })}
+              >
+                <button
+                  className={styles.paginationButton}
+                  onClick={() =>
+                    // 5. Jump to the nearest equivalent page.
+                    goTo(activePageIndex - activePageIndexToRender + i, {
+                      behavior: scrollBehavior
+                    })
+                  }
+                >
+                  {i + 1}
+                </button>
+              </li>
+            ))}
+          </ol>
+          <button
+            disabled={activePageIndex === pages.length - 1}
+            onClick={() => next({ behavior: scrollBehavior })}
+            className={styles.nextButton}
+          >
+            {String.fromCharCode(8594)}
+          </button>
+        </div>
+      </div>
+    );
+  }
+  // https://fettblog.eu/typescript-react-generic-forward-refs/
+) as <T extends any>(
+  props: InfiniteCarouselProps<T> & {
+    ref?: React.ForwardedRef<InfiniteCarouselRef>;
+  }
+) => React.ReactElement;
+
+export interface InfiniteCarouselItemProps {
+  readonly isSnapPoint: boolean;
+  readonly shouldSnap: boolean;
+  readonly bgColor: string;
+  readonly width?: number;
+  readonly children?: React.ReactNode;
+}
+
+export const InfiniteCarouselItem = ({
+  isSnapPoint,
+  shouldSnap,
+  bgColor,
+  width,
+  children
+}: InfiniteCarouselItemProps) => {
+  return (
+    <li
+      className={styles.item}
+      style={{
+        backgroundColor: bgColor,
+        width: width ?? '',
+        scrollSnapAlign: isSnapPoint ? 'start' : ''
+      }}
+      data-should-snap={shouldSnap}
+    >
+      {children}
+    </li>
+  );
+};


### PR DESCRIPTION
I finally came across a requirement for infinite carousels so I've made a minor tweak to react snap carousel to better support them.

The tweak isn't directly related to infinite carousels, but it helps with the implementation I'm using -- an example of which can be found in this PR.

Long story short, you can now add a data attribute `<li data-should-snap="true" />` to an item and it will become a snap point -- that is to say it will be used as the first item of a new page of items.

#### Why is it a DOM attribute and not a React prop?
Fundamentally React Snap Carousel computes "pages" based on the DOM layout which isn't modelled in React code, so it seems both appropriate and pragmatic to offer up a DOM-based API to tell React Snap Carousel where to start a page from -- it's conceptually the same as adding some CSS to an item, causing the page groupings to change.